### PR TITLE
 :see_no_evil:  création du .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.bin
+
+/public/uploads


### PR DESCRIPTION
on ignore les fichiers avec l'extension  .bin et le dossier /public/uploads